### PR TITLE
Add support for mushrooms to drop keys

### DIFF
--- a/platformer-kit/entities/key/key.tscn
+++ b/platformer-kit/entities/key/key.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=3 uid="uid://7dk38e0dxucg"]
+[gd_scene load_steps=13 format=3 uid="uid://7dk38e0dxucg"]
 
 [ext_resource type="Script" uid="uid://db25aveo5xn3l" path="res://entities/key/key.gd" id="1_6ag7p"]
 [ext_resource type="Texture2D" uid="uid://cy0javun1cgie" path="res://sprites/environment/props/key.png" id="1_gjwjf"]
@@ -8,6 +8,7 @@
 [ext_resource type="Texture2D" uid="uid://da2gggqivrgls" path="res://entities/gem/sprites/collect/item-feedback-4.png" id="6_nuy0w"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_6svch"]
+size = Vector2(15, 15)
 
 [sub_resource type="Animation" id="Animation_ef5b2"]
 length = 0.001
@@ -46,6 +47,30 @@ tracks/2/keys = {
 "transitions": PackedFloat32Array(1),
 "update": 1,
 "values": [ExtResource("3_241s1")]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath(".:collision_mask")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [1]
+}
+tracks/4/type = "value"
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/path = NodePath(".:freeze")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
 }
 
 [sub_resource type="Animation" id="Animation_sguu6"]
@@ -102,6 +127,30 @@ tracks/3/keys = {
 "update": 1,
 "values": [true]
 }
+tracks/4/type = "value"
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/path = NodePath(".:collision_mask")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [1]
+}
+tracks/5/type = "value"
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/path = NodePath(".:freeze")
+tracks/5/interp = 1
+tracks/5/loop_wrap = true
+tracks/5/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
 
 [sub_resource type="Animation" id="Animation_k6phr"]
 resource_name = "default"
@@ -150,26 +199,36 @@ _data = {
 &"default": SubResource("Animation_k6phr")
 }
 
-[node name="Key" type="Node2D"]
-scale = Vector2(0.75, 0.75)
+[sub_resource type="CircleShape2D" id="CircleShape2D_t15lu"]
+radius = 4.0
+
+[node name="Key" type="RigidBody2D"]
+collision_layer = 0
+lock_rotation = true
 script = ExtResource("1_6ag7p")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(2.08165e-12, 5)
+scale = Vector2(0.75, 0.75)
 texture = ExtResource("1_gjwjf")
 
 [node name="Area2D" type="Area2D" parent="."]
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
+position = Vector2(0, 1)
 shape = SubResource("RectangleShape2D_6svch")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {
-"": SubResource("AnimationLibrary_k40ri")
+&"": SubResource("AnimationLibrary_k40ri")
 }
 autoplay = "default"
 speed_scale = 0.75
 
 [node name="Sprite2D2" type="Sprite2D" parent="."]
-visible = false
+scale = Vector2(0.75, 0.75)
 texture = ExtResource("3_241s1")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0, 5.33333)
+shape = SubResource("CircleShape2D_t15lu")

--- a/platformer-kit/entities/mushroom/enemy.gd
+++ b/platformer-kit/entities/mushroom/enemy.gd
@@ -1,12 +1,17 @@
 extends CharacterBody2D
 class_name EnemyBody2D
 
+@export var drops_key := false
+var key_scene = preload("uid://7dk38e0dxucg")
+var dropped_items: Array[Node] = []
+
 @export var state_machine: EnemyStateMachine
 @export var animations: AnimationPlayer
 @export var death_state: CharacterState
 @export var respawnable := true
 
 var initial_position: Vector2
+var did_drop := false
 @export var max_health = 1
 var _current_health = 1
 
@@ -44,6 +49,14 @@ func _process(delta: float) -> void:
 		death.emit()
 
 func _on_death():
+	if drops_key and not did_drop:
+			var d: RigidBody2D = key_scene.instantiate()
+			get_tree().get_root().add_child(d)
+			d.position = global_position
+			d.linear_velocity = Vector2(randi_range(-100, 100), randi_range(-100, 0))
+			did_drop = true
+			dropped_items.append(d)
+
 	set_collision_layer_value(1, false)
 	set_collision_layer_value(2, false)
 	set_collision_mask_value(1, false)
@@ -62,3 +75,10 @@ func handle_reset():
 	visible = true
 	velocity = Vector2()
 	_current_health = max_health
+	did_drop = false
+	if drops_key:
+		LevelController.decrement_key_count()
+		did_drop = false
+		for d in dropped_items:
+			if is_instance_valid(d):
+				d.queue_free()


### PR DESCRIPTION
Mushrooms will now have an exported boolean `drops_key` that will cause the mushroom to spawn a key on death. If not collected, keys will be freed. If they are collected, and the player dies, the key counter is decremented.